### PR TITLE
Separate configuration and state

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,20 +30,29 @@ After cloning this repository, symlink `gmi` to somewhere on your path, or use `
 
 # Usage
 
-This assumes your root mail folder is in `~/.mail` and that this folder is _already_ set up with notmuch.
+This assumes your root mail folder is _already_ set up with notmuch.
 
-1. Make a directory for the gmailieer storage and state files (local repository).
+1. Configure the base mail directory (defaults to `~/.mail`), in
+   `$XDG_CONFIG_HOME/gmailieer/config`:
 
-```sh
-$ cd    ~/.mail
-$ mkdir account.gmail
-$ cd    account.gmail/
+```ini
+[DEFAULT]
+maildir_base = ~/Mail
 ```
 
-All commands should be run from the local mail repository unless otherwise specified.
+2. Optionally set up accounts to be stored in specific directories under
+   `maildir_base` (defaults to account name, i.e.\ email address), in
+   `$XDG_CONFIG_HOME/gmailieer/config`:
 
+```ini
+[your.email@gmail.com]
+dir = personal_mail
 
-2. Ignore the `.json` files in notmuch. Any tags listed in `new.tags` will be added to newly pulled messages. Process tags on new messages directly after running gmi, or run `notmuch new` to trigger the `post-new` hook for [initial tagging](https://notmuchmail.org/initial_tagging/). The `new.tags` are not ignored by default if you do not remove them, but you can prevent custom tags from being pushed to the remote by using e.g. `gmi set --ignore-tags-local new`.
+[your.work.email@gmail.com]
+dir = work_email
+```
+
+3. Ignore the `.json` files in notmuch. Any tags listed in `new.tags` will be added to newly pulled messages. Process tags on new messages directly after running gmi, or run `notmuch new` to trigger the `post-new` hook for [initial tagging](https://notmuchmail.org/initial_tagging/). The `new.tags` are not ignored by default if you do not remove them, but you can prevent custom tags from being pushed to the remote by using e.g. `gmi set --ignore-tags-local new`.
 
 ```
 [new]
@@ -51,7 +60,7 @@ tags=new
 ignore=*.json;
 ```
 
-3. Initialize the mail storage:
+4. Initialize the mail storage:
 
 ```sh
 $ gmi init your.email@gmail.com
@@ -61,7 +70,7 @@ $ gmi init your.email@gmail.com
 
 > The access token is stored in `.credentials.gmailieer.json` in the local mail repository. If you wish, you can specify [your own api key](#using-your-own-api-key) that should be used.
 
-4. You're now set up, and you can do the initial pull.
+5. You're now set up, and you can do the initial pull.
 
 > Use `gmi -h` or `gmi command -h` to get more usage information.
 
@@ -105,7 +114,7 @@ See below for more [caveats](#caveats).
 
 # Settings
 
-Gmailieer can be configured using `gmi set`. Use without any options to get a list of the current settings as well as the current history ID and notmuch revision.
+Gmailieer can be configured using `gmi set`. Use with an account to get a list of the current settings as well as the current history ID and notmuch revision.
 
 **`Account`** is the GMail account the repository is synced with. Configured during setup with [`gmi init`](#usage).
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -29,6 +29,8 @@ class Gmailieer:
     common.add_argument ('-s', '--no-progress', action = 'store_true',
         default = False, help = 'Disable progressbar (always off when output is not TTY)')
 
+    common.add_argument ('account', type = str, help = 'GMail account to use')
+
     subparsers = parser.add_subparsers (help = 'actions', dest = 'action')
     subparsers.required = True
 
@@ -112,8 +114,6 @@ class Gmailieer:
 
     parser_init.add_argument ('--no-auth', action = 'store_true', default = False,
         help = 'Do not immediately authorize as well (you will need to run \'auth\' afterwards)')
-
-    parser_init.add_argument ('account', type = str, help = 'GMail account to use')
 
     parser_init.set_defaults (func = self.initialize)
 
@@ -643,39 +643,42 @@ class Gmailieer:
     self.setup (args, False, True)
 
     if args.timeout is not None:
-      self.local.state.set_timeout (args.timeout)
+      self.local.config.set(self.args.account, "timeout", args.timeout)
 
     if args.replace_slash_with_dot:
-      self.local.state.set_replace_slash_with_dot (args.replace_slash_with_dot)
+      self.local.config.set(self.args.account, "replace_slash_with_dot", "true")
 
     if args.no_replace_slash_with_dot:
-      self.local.state.set_replace_slash_with_dot (not args.no_replace_slash_with_dot)
+      self.local.config.set(self.args.account, "replace_slash_with_dot", "false")
 
     if args.drop_non_existing_labels:
-      self.local.state.set_drop_non_existing_label (args.drop_non_existing_labels)
+      self.local.config.set(self.args.account, "drop_non_existing_label", "true")
 
     if args.no_drop_non_existing_labels:
-      self.local.state.set_drop_non_existing_label (not args.no_drop_non_existing_labels)
+      self.local.config.set(self.args.account, "drop_non_existing_label", "false")
 
     if args.ignore_tags_local is not None:
-      self.local.state.set_ignore_tags (args.ignore_tags_local)
+      self.local.config.set(self.args.account, "ignore_tags_local", args.ignore_tags_local)
 
     if args.ignore_tags_remote is not None:
-      self.local.state.set_ignore_remote_labels (args.ignore_tags_remote)
+      self.local.config.set(self.args.account, "ignore_tags_remote", args.ignore_tags_remote)
 
     if args.file_extension is not None:
-      self.local.state.set_file_extension (args.file_extension)
+      self.local.config.set(self.args.account, "file_extension", args.file_extension)
+
+    with open(self.local.config_f, mode="w") as fd:
+      self.local.config.write(fd)
 
     print ("Repository information and settings:")
-    print ("Account ...........: %s" % self.local.state.account)
+    print ("Account ...........: %s" % self.args.account)
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
-    print ("Timeout ...........: %f" % self.local.state.timeout)
-    print ("File extension ....: %s" % self.local.state.file_extension)
-    print ("Drop non existing labels...:", self.local.state.drop_non_existing_label)
-    print ("Replace . with / ..........:", self.local.state.replace_slash_with_dot)
-    print ("Ignore tags (local) .......:", self.local.state.ignore_tags)
-    print ("Ignore labels (remote) ....:", self.local.state.ignore_remote_labels)
+    print ("Timeout ...........: %f" % int(self.local.config.get(self.args.account, "timeout")))
+    print ("File extension ....: %s" % self.local.config.get(self.args.account, "file_extension"))
+    print ("Drop non existing labels...:", self.local.config.get(self.args.account, "drop_non_existing_label"))
+    print ("Replace . with / ..........:", self.local.config.get(self.args.account, "replace_slash_with_dot"))
+    print ("Ignore tags (local) .......:", self.local.config.get(self.args.account, "ignore_tags"))
+    print ("Ignore labels (remote) ....:", self.local.config.get(self.args.account, "ignore_remote_labels"))
 
 
 

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -9,6 +9,7 @@ import notmuch
 from .remote import Remote
 
 class Local:
+  config  = None
   wd      = None
   loaded  = False
 
@@ -60,15 +61,8 @@ class Local:
     # this is the last modification id of the notmuch db when the previous push was completed.
     lastmod = 0
 
-    replace_slash_with_dot = False
-    account = None
-    timeout = 0
-    drop_non_existing_label = False
-    ignore_tags = None
-    ignore_remote_labels = None
-    file_extension = None
-
     def __init__ (self, state_f):
+
       self.state_f = state_f
 
       if os.path.exists (self.state_f):
@@ -79,29 +73,17 @@ class Local:
 
       self.last_historyId = self.json.get ('last_historyId', 0)
       self.lastmod = self.json.get ('lastmod', 0)
-      self.replace_slash_with_dot = self.json.get ('replace_slash_with_dot', False)
-      self.account = self.json.get ('account', 'me')
-      self.timeout = self.json.get ('timeout', 0)
-      self.drop_non_existing_label = self.json.get ('drop_non_existing_label', False)
-      self.ignore_tags = set(self.json.get ('ignore_tags', []))
-      self.ignore_remote_labels = set(self.json.get ('ignore_remote_labels', Remote.DEFAULT_IGNORE_LABELS))
-      self.file_extension = self.json.get ('file_extension', '')
 
     def write (self):
       self.json = {}
 
       self.json['last_historyId'] = self.last_historyId
       self.json['lastmod'] = self.lastmod
-      self.json['replace_slash_with_dot'] = self.replace_slash_with_dot
-      self.json['account'] = self.account
-      self.json['timeout'] = self.timeout
-      self.json['drop_non_existing_label'] = self.drop_non_existing_label
-      self.json['ignore_tags'] = list(self.ignore_tags)
-      self.json['ignore_remote_labels'] = list(self.ignore_remote_labels)
-      self.json['file_extension'] = self.file_extension
 
       if os.path.exists (self.state_f):
         shutil.copyfile (self.state_f, self.state_f + '.bak')
+      else:
+        os.mkdir(os.path.dirname(self.state_f), 0o755)
 
       with tempfile.NamedTemporaryFile (mode = 'w+', dir = os.path.dirname (self.state_f), delete = False) as fd:
         json.dump (self.json, fd)
@@ -115,52 +97,39 @@ class Local:
       self.lastmod = m
       self.write ()
 
-    def set_account (self, a):
-      self.account = a
-      self.write ()
-
-    def set_timeout (self, t):
-      self.timeout = t
-      self.write ()
-
-    def set_replace_slash_with_dot (self, r):
-      self.replace_slash_with_dot = r
-      self.write ()
-
-    def set_drop_non_existing_label (self, r):
-      self.drop_non_existing_label = r
-      self.write ()
-
-    def set_ignore_tags (self, t):
-      if len(t.strip ()) == 0:
-        self.ignore_tags = set()
-      else:
-        self.ignore_tags = set([ tt.strip () for tt in t.split(',') ])
-
-      self.write ()
-
-    def set_ignore_remote_labels (self, t):
-      if len(t.strip ()) == 0:
-        self.ignore_remote_labels = set()
-      else:
-        self.ignore_remote_labels = set([ tt.strip () for tt in t.split(',') ])
-
-      self.write ()
-
-    def set_file_extension (self, t):
-      try:
-        with tempfile.NamedTemporaryFile (dir = os.path.dirname (self.state_f), suffix = t) as fd:
-          pass
-
-        self.file_extension = t.strip ()
-        self.write ()
-      except OSError:
-        print ("Failed creating test file with file extension: " + t + ", not set.")
-        raise
-
   def __init__ (self, g):
     self.gmailieer = g
-    self.wd = os.getcwd ()
+
+    xdg_config_home = os.getenv ('XDG_CONFIG_HOME', os.path.expanduser ('~/.config'))
+    self.config_f = os.path.join(xdg_config_home, "gmailieer", "config")
+
+    self.config = configparser.ConfigParser({
+        'maildir_base': '~/.mail',
+        'replace_slash_with_dot': 'false',
+        'timeout': '0',
+        'drop_non_existing_label': 'false',
+        'ignore_tags': '',
+        'ignore_remote_labels': ','.join(
+            ['CATEGORY_PERSONAL', 'CATEGORY_SOCIAL', 'CATEGORY_PROMOTIONS',
+                'CATEGORY_UPDATES', 'CATEGORY_FORUMS' ]),
+        'file_extension': ''
+        })
+    self.config.read(self.config_f)
+    subdir = ""
+    try:
+      subdir = self.config.get(g.args.account, "dir")
+    except configparser.NoSectionError:
+      self.config.add_section(g.args.account)
+      self.config.set(g.args.account, "dir", g.args.account)
+    except configparser.NoOptionError:
+      self.config.set(g.args.account, "dir", g.args.account)
+    finally:
+      with open(self.config_f, mode="w") as fd:
+        self.config.write(fd)
+      subdir = self.config.get(g.args.account, "dir")
+    maildir_base = self.config.get(g.args.account, "maildir_base")
+
+    self.wd = os.path.expanduser(os.path.join(maildir_base, subdir))
     self.dry_run = g.dry_run
 
     # state file for local repository
@@ -183,7 +152,7 @@ class Local:
 
     self.state = Local.State (self.state_f)
 
-    self.ignore_labels = self.ignore_labels | self.state.ignore_tags
+    self.ignore_labels = self.ignore_labels | set(self.config.get(self.gmailieer.args.account, "ignore_tags").split(","))
 
     ## Check if we are in the notmuch db
     with notmuch.Database () as db:
@@ -259,9 +228,10 @@ class Local:
       raise Local.RepositoryException ("'mail' exists: this repository seems to already be set up!")
 
     self.state = Local.State (self.state_f)
-    self.state.replace_slash_with_dot = replace_slash_with_dot
-    self.state.account = account
-    self.state.write ()
+    self.state.write()
+    self.config.set(self.gmailieer.args.account, "replace_slash_with_dot", "true" if replace_slash_with_dot else "false")
+    with open(self.config_f, mode="w") as fd:
+      self.config.write(fd)
     os.makedirs (os.path.join (self.md, 'cur'))
     os.makedirs (os.path.join (self.md, 'new'))
     os.makedirs (os.path.join (self.md, 'tmp'))
@@ -326,22 +296,22 @@ class Local:
 
   def __filename_to_gid__ (self, fname):
     ext = ''
-    if self.state.file_extension:
-        ext = '.' + self.state.file_extension
+    if self.config.get(self.gmailieer.args.account, "file_extension"):
+        ext = '.' + self.config.get(self.gmailieer.args.account, "file_extension")
     ext += ':2,'
 
     f = fname.rfind (ext)
     if f > 5:
       return fname[:f]
     else:
-      print ("'%s' does not contain valid maildir delimter, correct file name extension, or does not seem to have a valid GID, ignoring.")
+      print ("'%s' does not contain valid maildir delimiter, correct file name extension, or does not seem to have a valid GID, ignoring.")
       return None
 
   def __make_maildir_name__ (self, m, labels):
     # http://cr.yp.to/proto/maildir.html
     ext = ''
-    if self.state.file_extension:
-        ext = '.' + self.state.file_extension
+    if self.config.get(self.gmailieer.args.account, "file_extension"):
+        ext = '.' + self.config.get(self.gmailieer.args.account, "file_extension")
 
     p = m + ext + ':'
     info = '2,'
@@ -436,7 +406,7 @@ class Local:
     for l in glabels:
       ll = self.gmailieer.remote.labels.get(l, None)
 
-      if ll is None and not self.state.drop_non_existing_label:
+      if ll is None and self.config.get(self.gmailieer.args.account, "drop_non_existing_label").lower() != "true":
         err = "error: GMail supplied a label that there exists no record for! You can `gmi set --drop-non-existing-labels` to work around the issue (https://github.com/gauteh/gmailieer/issues/48)"
         print (err)
         raise Local.RepositoryException (err)
@@ -453,7 +423,7 @@ class Local:
     labels = [self.translate_labels.get (l, l) for l in labels]
 
     # this is my weirdness
-    if self.state.replace_slash_with_dot:
+    if self.config.get(self.gmailieer.args.account, "replace_slash_with_dot").lower() == "true":
       labels = [l.replace ('/', '.') for l in labels]
 
     if fname is None:

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -121,11 +121,9 @@ class Local:
     except configparser.NoSectionError:
       self.config.add_section(g.args.account)
       self.config.set(g.args.account, "dir", g.args.account)
+      subdir = self.config.get(g.args.account, "dir")
     except configparser.NoOptionError:
       self.config.set(g.args.account, "dir", g.args.account)
-    finally:
-      with open(self.config_f, mode="w") as fd:
-        self.config.write(fd)
       subdir = self.config.get(g.args.account, "dir")
     maildir_base = self.config.get(g.args.account, "maildir_base")
 
@@ -230,8 +228,11 @@ class Local:
     self.state = Local.State (self.state_f)
     self.state.write()
     self.config.set(self.gmailieer.args.account, "replace_slash_with_dot", "true" if replace_slash_with_dot else "false")
-    with open(self.config_f, mode="w") as fd:
-      self.config.write(fd)
+    try:
+      with open(self.config_f, mode="w") as fd:
+        self.config.write(fd)
+    except PermissionError:
+      print ("config file %s not writable" % self.config_f)
     os.makedirs (os.path.join (self.md, 'cur'))
     os.makedirs (os.path.join (self.md, 'new'))
     os.makedirs (os.path.join (self.md, 'tmp'))

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -104,10 +104,10 @@ class Remote:
     assert g.local.loaded, "local repository must be loaded!"
 
     self.CLIENT_SECRET_FILE = g.credentials_file
-    self.account = g.local.state.account
+    self.account = g.args.account
     self.dry_run = g.dry_run
 
-    self.ignore_labels = self.gmailieer.local.state.ignore_remote_labels
+    self.ignore_labels = set(self.gmailieer.local.config.get(self.account, "ignore_remote_labels").split(","))
 
   def __require_auth__ (func):
     def func_wrap (self, *args, **kwargs):
@@ -378,7 +378,7 @@ class Remote:
 
     self.credentials = self.__get_credentials__ ()
 
-    timeout = self.gmailieer.local.state.timeout
+    timeout = int(self.gmailieer.local.config.get(self.account, "timeout"))
     if timeout == 0: timeout = None
 
     self.http = self.credentials.authorize (httplib2.Http(timeout = timeout))
@@ -469,7 +469,7 @@ class Remote:
     for l in glabels:
       ll = self.labels.get(l, None)
 
-      if ll is None and not self.gmailieer.local.state.drop_non_existing_label:
+      if ll is None and self.gmailieer.local.config.get(self.account, "drop_non_existing_label").lower() != "true":
         err = "error: GMail supplied a label that there exists no record for! You can `gmi set --drop-non-existing-labels` to work around the issue (https://github.com/gauteh/gmailieer/issues/48)"
         print (err)
         raise Remote.GenericException (err)
@@ -486,7 +486,7 @@ class Remote:
     labels = [self.gmailieer.local.translate_labels.get (l, l) for l in labels]
 
     # this is my weirdness
-    if self.gmailieer.local.state.replace_slash_with_dot:
+    if self.gmailieer.local.config.get(self.account, "replace_slash_with_dot").lower() == "true":
       labels = [l.replace ('/', '.') for l in labels]
 
     labels = set(labels)
@@ -504,7 +504,7 @@ class Remote:
     add = [self.gmailieer.local.labels_translate.get (k, k) for k in add]
     rem = [self.gmailieer.local.labels_translate.get (k, k) for k in rem]
 
-    if self.gmailieer.local.state.replace_slash_with_dot:
+    if self.gmailieer.local.config.get(self.account, "replace_slash_with_dot").lower() == "true":
       add = [a.replace ('.', '/') for a in add]
       rem = [r.replace ('.', '/') for r in rem]
 


### PR DESCRIPTION
Resolves #101 

This change introduces a configuration file, stored at `$XDG_CONFIG_HOME/gmailieer/config` (which is `~/.config/gmailieer/config` on most Linux systems) which contains the sync settings. Multiple accounts utilise the same configuration file, with their associated credentials still in the same places as previously (e.g.\ `~/.mail/personal/.credentials.gmailieer.json`, `~/.mail/work/.credentials.gmailieer.json`).

In addition, `gmi` commands are callable irrespective of their current directory, and all subcommands now expect an account to operate on (e.g. `cd ~/.mail/personal && gmi sync` becomes `gmi sync my.email@gmail.com`, where you would have something like
```ini
[my.email@gmail.com]
dir=personal
```
in your config).