### PR TITLE
Pull static config into Config object

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -643,39 +643,39 @@ class Gmailieer:
     self.setup (args, False, True)
 
     if args.timeout is not None:
-      self.local.state.set_timeout (args.timeout)
+      self.local.config.set_timeout (args.timeout)
 
     if args.replace_slash_with_dot:
-      self.local.state.set_replace_slash_with_dot (args.replace_slash_with_dot)
+      self.local.config.set_replace_slash_with_dot (args.replace_slash_with_dot)
 
     if args.no_replace_slash_with_dot:
-      self.local.state.set_replace_slash_with_dot (not args.no_replace_slash_with_dot)
+      self.local.config.set_replace_slash_with_dot (not args.no_replace_slash_with_dot)
 
     if args.drop_non_existing_labels:
-      self.local.state.set_drop_non_existing_label (args.drop_non_existing_labels)
+      self.local.config.set_drop_non_existing_label (args.drop_non_existing_labels)
 
     if args.no_drop_non_existing_labels:
-      self.local.state.set_drop_non_existing_label (not args.no_drop_non_existing_labels)
+      self.local.config.set_drop_non_existing_label (not args.no_drop_non_existing_labels)
 
     if args.ignore_tags_local is not None:
-      self.local.state.set_ignore_tags (args.ignore_tags_local)
+      self.local.config.set_ignore_tags (args.ignore_tags_local)
 
     if args.ignore_tags_remote is not None:
-      self.local.state.set_ignore_remote_labels (args.ignore_tags_remote)
+      self.local.config.set_ignore_remote_labels (args.ignore_tags_remote)
 
     if args.file_extension is not None:
-      self.local.state.set_file_extension (args.file_extension)
+      self.local.config.set_file_extension (args.file_extension)
 
     print ("Repository information and settings:")
-    print ("Account ...........: %s" % self.local.state.account)
+    print ("Account ...........: %s" % self.local.config.account)
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
-    print ("Timeout ...........: %f" % self.local.state.timeout)
-    print ("File extension ....: %s" % self.local.state.file_extension)
-    print ("Drop non existing labels...:", self.local.state.drop_non_existing_label)
-    print ("Replace . with / ..........:", self.local.state.replace_slash_with_dot)
-    print ("Ignore tags (local) .......:", self.local.state.ignore_tags)
-    print ("Ignore labels (remote) ....:", self.local.state.ignore_remote_labels)
+    print ("Timeout ...........: %f" % self.local.config.timeout)
+    print ("File extension ....: %s" % self.local.config.file_extension)
+    print ("Drop non existing labels...:", self.local.config.drop_non_existing_label)
+    print ("Replace . with / ..........:", self.local.config.replace_slash_with_dot)
+    print ("Ignore tags (local) .......:", self.local.config.ignore_tags)
+    print ("Ignore labels (remote) ....:", self.local.config.ignore_remote_labels)
 
 
 

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -104,10 +104,10 @@ class Remote:
     assert g.local.loaded, "local repository must be loaded!"
 
     self.CLIENT_SECRET_FILE = g.credentials_file
-    self.account = g.local.state.account
+    self.account = g.local.config.account
     self.dry_run = g.dry_run
 
-    self.ignore_labels = self.gmailieer.local.state.ignore_remote_labels
+    self.ignore_labels = self.gmailieer.local.config.ignore_remote_labels
 
   def __require_auth__ (func):
     def func_wrap (self, *args, **kwargs):
@@ -378,7 +378,7 @@ class Remote:
 
     self.credentials = self.__get_credentials__ ()
 
-    timeout = self.gmailieer.local.state.timeout
+    timeout = self.gmailieer.local.config.timeout
     if timeout == 0: timeout = None
 
     self.http = self.credentials.authorize (httplib2.Http(timeout = timeout))
@@ -469,7 +469,7 @@ class Remote:
     for l in glabels:
       ll = self.labels.get(l, None)
 
-      if ll is None and not self.gmailieer.local.state.drop_non_existing_label:
+      if ll is None and not self.gmailieer.local.config.drop_non_existing_label:
         err = "error: GMail supplied a label that there exists no record for! You can `gmi set --drop-non-existing-labels` to work around the issue (https://github.com/gauteh/lieer/issues/48)"
         print (err)
         raise Remote.GenericException (err)
@@ -486,7 +486,7 @@ class Remote:
     labels = [self.gmailieer.local.translate_labels.get (l, l) for l in labels]
 
     # this is my weirdness
-    if self.gmailieer.local.state.replace_slash_with_dot:
+    if self.gmailieer.local.config.replace_slash_with_dot:
       labels = [l.replace ('/', '.') for l in labels]
 
     labels = set(labels)
@@ -504,7 +504,7 @@ class Remote:
     add = [self.gmailieer.local.labels_translate.get (k, k) for k in add]
     rem = [self.gmailieer.local.labels_translate.get (k, k) for k in rem]
 
-    if self.gmailieer.local.state.replace_slash_with_dot:
+    if self.gmailieer.local.config.replace_slash_with_dot:
       add = [a.replace ('.', '/') for a in add]
       rem = [r.replace ('.', '/') for r in rem]
 


### PR DESCRIPTION
This is a simpler implementation of #117.

- Pull all static config values into a `Local.Config` class. `Local.State` now just contains `last_historyId` and `lastmod`.
- `Local.Config` loads from `.gmailieer.json` as before.
- `Local.State` first attempts to load from `.state.gmailieer.json`, falling back to `.gmailieer.json` if the state file doesn't exist.
- `Local.State` always writes to `.state.gmailieer.json`.
- `Local` now has a `config` field, and everything referencing the old values in `state` is now referencing those same values from `config`.

I am currently using this and it appears to work fine. The old `last_historyId` and `lastmod` values stick around in `.gmailieer.json` until the config is modified.