### PR TITLE
Allow to only fetch recent emails

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ Lieer can be configured using `gmi set`. Use without any options to get a list o
 
 **`historyId`** is the latest synced GMail revision. Anything since this ID will be fetched on the next [`gmi pull`](#pull) (partial).
 
-**`age`** is the maximum age of email. This is an partial implementation of [the `newer_than` search operator](https://support.google.com/mail/answer/7190?hl=en). Any email newer than this age (unit: month) will be fetched on the next [`gmi pull`](#pull). If you change this parameter to an older age, you need to do a full pull.
+**`age`** is the maximum age of email (unit: month). This is an partial implementation of [the `newer_than` search operator](https://support.google.com/mail/answer/7190?hl=en). Any email newer than this age will be fetched on the next [`gmi pull`](#pull). If you change this parameter to an older age, you need to do a full pull. *Note that this is an experimental feature for now*. If necessary, you can use `gmi set --unset-age` to remove it from the configuration.
 
 **`lastmod`** is the latest synced Notmuch database revision. Anything changed after this revision will be pushed on [`gmi push`](#ush).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,11 +111,13 @@ Lieer can be configured using `gmi set`. Use without any options to get a list o
 
 **`historyId`** is the latest synced GMail revision. Anything since this ID will be fetched on the next [`gmi pull`](#pull) (partial).
 
+**`age`** is the maximum age of email. This is an partial implementation of [the `newer_than` search operator](https://support.google.com/mail/answer/7190?hl=en). Anything email newer than this age (unit: month) will be fetched on the next [`gmi pull`](#pull). If you change this parameter to an older age, you need to do a full pull.
+
 **`lastmod`** is the latest synced Notmuch database revision. Anything changed after this revision will be pushed on [`gmi push`](#ush).
 
 **`Timeout`** is the timeout in seconds used for the HTTP connection to GMail. `0` means the forever or system error/timeout, [whichever occurs first](https://github.com/gauteh/lieer/issues/83#issuecomment-396487919).
 
-**`File extension`** is an optional argument to include the specified extension in local file names (e.g., `mbox`) which can be useful for indexing them with third-party programs.  
+**`File extension`** is an optional argument to include the specified extension in local file names (e.g., `mbox`) which can be useful for indexing them with third-party programs.
 
 *Important:* If you change this setting after synchronizing, the best case scenario is that all files will apear to not have being pulled down and will be re-downloaded (and duplicated with a different extension in the maildir). There might also be changes to tags. You should in theory be able to change it by renaming all files, but since this will update the lastmod you will get a check on all files.
 
@@ -124,11 +126,11 @@ Lieer can be configured using `gmi set`. Use without any options to get a list o
 **`Replace slash with dot`** is used to replace the sub-label separator (`/`) with a dot (`.`). I think this is easier to work with. *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
 
 **`Ignore tags (local)`** can be used to specify a list of tags which should not be synced from local to remote (e.g. [`new`](#usage)). In addition to the user-configured tags these tags are ignored: `'attachment', 'encrypted', 'signed', 'passed', 'replied', 'muted', 'mute', 'todo', 'Trash', 'voicemail'`. Some are special tags in notmuch and some are unsupported by GMail. See [Caveats](#caveats) below for more explanations. *Note:* This setting expects [_translated_ tags](#translation-between-labels-and-tags).
-  
+
   *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
 
 **`Ignore tags (remote)`** can be used to specify a list of tags (labels) which should not be synced from remote (GMail) to local. By default the [`CATEGORY_*` type](https://developers.google.com/gmail/api/guides/labels) labels which are mapped to the Personal/Promotions/etc tabs in the GMail interface are ignored. You can specify that no label should ignored by doing: `gmi set --ignore-tags-remote ""`. *Note:* This setting expects [_*un*translated_ tags](#translation-between-labels-and-tags).
-  
+
   *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ Lieer can be configured using `gmi set`. Use without any options to get a list o
 
 **`historyId`** is the latest synced GMail revision. Anything since this ID will be fetched on the next [`gmi pull`](#pull) (partial).
 
-**`age`** is the maximum age of email. This is an partial implementation of [the `newer_than` search operator](https://support.google.com/mail/answer/7190?hl=en). Anything email newer than this age (unit: month) will be fetched on the next [`gmi pull`](#pull). If you change this parameter to an older age, you need to do a full pull.
+**`age`** is the maximum age of email. This is an partial implementation of [the `newer_than` search operator](https://support.google.com/mail/answer/7190?hl=en). Any email newer than this age (unit: month) will be fetched on the next [`gmi pull`](#pull). If you change this parameter to an older age, you need to do a full pull.
 
 **`lastmod`** is the latest synced Notmuch database revision. Anything changed after this revision will be pushed on [`gmi push`](#ush).
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -45,9 +45,6 @@ class Gmailieer:
     parser_pull.add_argument ('--limit', type = int, default = None,
         help = 'Maximum number of messages to pull (soft limit, GMail may return more), note that this may upset the tally of synchronized messages.')
 
-    parser_pull.add_argument ('--age', type = int, default = None,
-        help = 'Maximum age (unit: month) of messages to pull')
-
     parser_pull.add_argument ('-d', '--dry-run', action='store_true',
         default = False, help = 'do not make any changes')
 
@@ -83,9 +80,6 @@ class Gmailieer:
     parser_sync.add_argument ('--limit', type = int, default = None,
         help = 'Maximum number of messages to sync, note that this may upset the tally of synchronized messages.')
 
-    parser_sync.add_argument ('--age', type = int, default = None,
-        help = 'Maximum age (unit: month) of messages to pull')
-
     parser_sync.add_argument ('-d', '--dry-run', action='store_true',
         default = False, help = 'do not make any changes')
 
@@ -114,9 +108,6 @@ class Gmailieer:
 
     parser_init.add_argument ('--replace-slash-with-dot', action = 'store_true', default = False,
         help = 'This will replace \'/\' with \'.\' in gmail labels (make sure you realize the implications)')
-
-    parser_init.add_argument ('--age', type = int, default = None,
-        help = 'Maximum age (unit: month) of messages to pull')
 
     parser_init.add_argument ('--no-auth', action = 'store_true', default = False,
         help = 'Do not immediately authorize as well (you will need to run \'auth\' afterwards)')
@@ -339,7 +330,6 @@ class Gmailieer:
       self.list_labels      = args.list_labels
       self.force            = args.force
       self.limit            = args.limit
-      self.age              = args.age
 
       self.remote.get_labels () # to make sure label map is initialized
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -45,6 +45,8 @@ class Gmailieer:
     parser_pull.add_argument ('--limit', type = int, default = None,
         help = 'Maximum number of messages to pull (soft limit, GMail may return more), note that this may upset the tally of synchronized messages.')
 
+    parser_pull.add_argument ('--age', type = int, default = None,
+        help = 'Maximum age (unit: month) of messages to pull')
 
     parser_pull.add_argument ('-d', '--dry-run', action='store_true',
         default = False, help = 'do not make any changes')
@@ -110,6 +112,9 @@ class Gmailieer:
     parser_init.add_argument ('--replace-slash-with-dot', action = 'store_true', default = False,
         help = 'This will replace \'/\' with \'.\' in gmail labels (make sure you realize the implications)')
 
+    parser_init.add_argument ('--age', type = int, default = None,
+        help = 'Maximum age (unit: month) of messages to pull')
+
     parser_init.add_argument ('--no-auth', action = 'store_true', default = False,
         help = 'Do not immediately authorize as well (you will need to run \'auth\' afterwards)')
 
@@ -126,6 +131,9 @@ class Gmailieer:
 
     parser_set.add_argument ('-t', '--timeout', type = float,
         default = None, help = 'Set HTTP timeout in seconds (0 means forever or system timeout)')
+
+    parser_set.add_argument ('--age', type = int, default = None,
+        help = 'Maximum age (unit: month) of messages to pull')
 
     parser_set.add_argument ('--replace-slash-with-dot', action = 'store_true', default = False,
         help = 'This will replace \'/\' with \'.\' in gmail labels (Important: see the manual and make sure you realize the implications)')
@@ -191,6 +199,7 @@ class Gmailieer:
     self.dry_run          = dry_run
     self.HAS_TQDM         = (not args.no_progress)
     self.credentials_file = args.credentials
+    self.age = args.age
 
     if self.HAS_TQDM:
       if not (sys.stderr.isatty() and sys.stdout.isatty()):
@@ -327,6 +336,7 @@ class Gmailieer:
       self.list_labels      = args.list_labels
       self.force            = args.force
       self.limit            = args.limit
+      self.age              = args.age
 
       self.remote.get_labels () # to make sure label map is initialized
 
@@ -650,6 +660,9 @@ class Gmailieer:
     if args.timeout is not None:
       self.local.config.set_timeout (args.timeout)
 
+    if args.age is not None:
+      self.local.config.set_age (args.age)
+
     if args.replace_slash_with_dot:
       self.local.config.set_replace_slash_with_dot (args.replace_slash_with_dot)
 
@@ -682,6 +695,7 @@ class Gmailieer:
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
     print ("Timeout ...........: %f" % self.local.config.timeout)
+    print ("Age ...............: %d" % self.local.config.age)
     print ("File extension ....: %s" % self.local.config.file_extension)
     print ("Drop non existing labels...:", self.local.config.drop_non_existing_label)
     print ("Ignore empty history ......:", self.local.config.ignore_empty_history)

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -83,6 +83,9 @@ class Gmailieer:
     parser_sync.add_argument ('--limit', type = int, default = None,
         help = 'Maximum number of messages to sync, note that this may upset the tally of synchronized messages.')
 
+    parser_sync.add_argument ('--age', type = int, default = None,
+        help = 'Maximum age (unit: month) of messages to pull')
+
     parser_sync.add_argument ('-d', '--dry-run', action='store_true',
         default = False, help = 'do not make any changes')
 
@@ -199,7 +202,7 @@ class Gmailieer:
     self.dry_run          = dry_run
     self.HAS_TQDM         = (not args.no_progress)
     self.credentials_file = args.credentials
-    self.age = args.age
+    self.age = args.age if hasattr(args, 'property') else None
 
     if self.HAS_TQDM:
       if not (sys.stderr.isatty() and sys.stdout.isatty()):
@@ -654,7 +657,6 @@ class Gmailieer:
     return need_content
 
   def set (self, args):
-    args.credentials = '' # for setup()
     self.setup (args, False, True)
 
     if args.timeout is not None:

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -202,7 +202,7 @@ class Gmailieer:
     self.dry_run          = dry_run
     self.HAS_TQDM         = (not args.no_progress)
     self.credentials_file = args.credentials
-    self.age = args.age if hasattr(args, 'property') else None
+    self.age = args.age if hasattr(args, 'age') else None
 
     if self.HAS_TQDM:
       if not (sys.stderr.isatty() and sys.stdout.isatty()):

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -129,6 +129,8 @@ class Gmailieer:
     parser_set.add_argument ('--age', type = int, default = None,
         help = 'Maximum age (unit: month) of messages to pull')
 
+    parser_set.add_argument ('--unset-age', action = 'store_true', default = False)
+
     parser_set.add_argument ('--replace-slash-with-dot', action = 'store_true', default = False,
         help = 'This will replace \'/\' with \'.\' in gmail labels (Important: see the manual and make sure you realize the implications)')
 
@@ -193,7 +195,6 @@ class Gmailieer:
     self.dry_run          = dry_run
     self.HAS_TQDM         = (not args.no_progress)
     self.credentials_file = args.credentials
-    self.age = args.age if hasattr(args, 'age') else None
 
     if self.HAS_TQDM:
       if not (sys.stderr.isatty() and sys.stdout.isatty()):
@@ -655,6 +656,9 @@ class Gmailieer:
     if args.age is not None:
       self.local.config.set_age (args.age)
 
+    if args.unset_age:
+      self.local.config.set_age (-1)
+
     if args.replace_slash_with_dot:
       self.local.config.set_replace_slash_with_dot (args.replace_slash_with_dot)
 
@@ -687,7 +691,9 @@ class Gmailieer:
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
     print ("Timeout ...........: %f" % self.local.config.timeout)
-    print ("Age ...............: %d" % self.local.config.age)
+    age = self.local.config.age
+    if age and self.local.config.age != -1 :
+        print ("Age ...............: %d months" % self.local.config.age)
     print ("File extension ....: %s" % self.local.config.file_extension)
     print ("Drop non existing labels...:", self.local.config.drop_non_existing_label)
     print ("Ignore empty history ......:", self.local.config.ignore_empty_history)

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -73,11 +73,13 @@ class Local:
           print ("Failed to decode config file `{}`.".format (self.config_f))
           raise
       else:
+
         self.json = {}
 
       self.replace_slash_with_dot = self.json.get ('replace_slash_with_dot', False)
       self.account = self.json.get ('account', 'me')
       self.timeout = self.json.get ('timeout', 0)
+      self.age = self.json.get ('age', None)
       self.drop_non_existing_label = self.json.get ('drop_non_existing_label', False)
       self.ignore_empty_history = self.json.get ('ignore_empty_history', False)
       self.ignore_tags = set(self.json.get ('ignore_tags', []))
@@ -90,6 +92,7 @@ class Local:
       self.json['replace_slash_with_dot'] = self.replace_slash_with_dot
       self.json['account'] = self.account
       self.json['timeout'] = self.timeout
+      self.json['age'] = self.age
       self.json['drop_non_existing_label'] = self.drop_non_existing_label
       self.json['ignore_empty_history'] = self.ignore_empty_history
       self.json['ignore_tags'] = list(self.ignore_tags)
@@ -109,6 +112,10 @@ class Local:
 
     def set_timeout (self, t):
       self.timeout = t
+      self.write ()
+
+    def set_age (self, a):
+      self.age = a
       self.write ()
 
     def set_replace_slash_with_dot (self, r):
@@ -221,6 +228,7 @@ class Local:
     self.gmailieer = g
     self.wd = os.getcwd ()
     self.dry_run = g.dry_run
+    self.age = g.age
 
     # config and state files for local repository
     self.config_f = os.path.join (self.wd, '.gmailieer.json')
@@ -246,6 +254,7 @@ class Local:
 
     self.ignore_labels = self.ignore_labels | self.config.ignore_tags
 
+    self.age = self.age if self.age else self.config.age
     ## Check if we are in the notmuch db
     with notmuch.Database () as db:
       try:
@@ -306,7 +315,7 @@ class Local:
       m = self.__filename_to_gid__ (os.path.basename (f))
       self.gids[m] = f
 
-  def initialize_repository (self, replace_slash_with_dot, account):
+  def initialize_repository (self, replace_slash_with_dot, account, age):
     """
     Sets up a local repository
     """
@@ -322,6 +331,7 @@ class Local:
     self.config = Local.Config (self.config_f)
     self.config.replace_slash_with_dot = replace_slash_with_dot
     self.config.account = account
+    self.config.age = age
     self.config.write ()
     os.makedirs (os.path.join (self.md, 'cur'))
     os.makedirs (os.path.join (self.md, 'new'))

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -92,7 +92,8 @@ class Local:
       self.json['replace_slash_with_dot'] = self.replace_slash_with_dot
       self.json['account'] = self.account
       self.json['timeout'] = self.timeout
-      self.json['age'] = self.age
+      if self.age != -1:
+          self.json['age'] = self.age
       self.json['drop_non_existing_label'] = self.drop_non_existing_label
       self.json['ignore_empty_history'] = self.ignore_empty_history
       self.json['ignore_tags'] = list(self.ignore_tags)
@@ -114,8 +115,12 @@ class Local:
       self.timeout = t
       self.write ()
 
-    def set_age (self, a):
-      self.age = a
+    def set_age (self, n):
+      """set age
+
+      if n=-1, age parameter will be unset when saving the config
+      """
+      self.age = n
       self.write ()
 
     def set_replace_slash_with_dot (self, r):

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -228,7 +228,6 @@ class Local:
     self.gmailieer = g
     self.wd = os.getcwd ()
     self.dry_run = g.dry_run
-    self.age = g.age
 
     # config and state files for local repository
     self.config_f = os.path.join (self.wd, '.gmailieer.json')
@@ -254,7 +253,7 @@ class Local:
 
     self.ignore_labels = self.ignore_labels | self.config.ignore_tags
 
-    self.age = self.age if self.age else self.config.age
+    self.age = self.config.age
     ## Check if we are in the notmuch db
     with notmuch.Database () as db:
       try:

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -106,8 +106,8 @@ class Remote:
     self.CLIENT_SECRET_FILE = g.credentials_file
     self.account = g.local.config.account
     self.dry_run = g.dry_run
-    if g.local.age:
-       self.query = "newer_than:{}m".format(g.local.age)
+    if g.local.config.age:
+       self.query += " newer_than:{}m".format(g.local.config.age)
 
     self.ignore_labels = self.gmailieer.local.config.ignore_remote_labels
 

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -106,6 +106,8 @@ class Remote:
     self.CLIENT_SECRET_FILE = g.credentials_file
     self.account = g.local.config.account
     self.dry_run = g.dry_run
+    if g.local.age:
+       self.query = "newer_than:{}m".format(g.local.age)
 
     self.ignore_labels = self.gmailieer.local.config.ignore_remote_labels
 


### PR DESCRIPTION
This is an partial implementation of [the `newer_than` search operator](https://support.google.com/mail/answer/7190?hl=en). Only emails newer than specified months will be fetched. This feature will fix #93.