### PR TITLE
Set `long_description_content_type` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
 
     description='Fast fetch and two-way tag synchronization between notmuch and GMail',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
     url='https://github.com/gauteh/lieer',


### PR DESCRIPTION
This is required by PyPI if the description format is not the default (restructured text).

On that note, I should add that I've been uploading lieer source dists to PyPI so that users can do a simple `pip install lieer`: https://github.com/apetresc/lieer/pull/new/pypi-compat. This is the only change that is required to make it compatible.

If you would prefer to take over the PyPI entry for the project, please let me know! I will happily transfer it over (and can even help you write a Github Actions workflow to automatically deploy it there whenever you create a tagged release)