### PR TITLE
add option for removing messages locally that have been deleted remot…

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -77,6 +77,7 @@ class Local:
     ignore_empty_history = False
     ignore_tags = None
     ignore_remote_labels = None
+    remove_local_messages = True
     file_extension = None
 
     def __init__ (self, config_f):
@@ -97,6 +98,7 @@ class Local:
       self.timeout = self.json.get ('timeout', 0)
       self.drop_non_existing_label = self.json.get ('drop_non_existing_label', False)
       self.ignore_empty_history = self.json.get ('ignore_empty_history', False)
+      self.remove_local_messages = self.json.get ('remove_local_messages', True)
       self.ignore_tags = set(self.json.get ('ignore_tags', []))
       self.ignore_remote_labels = set(self.json.get ('ignore_remote_labels', Remote.DEFAULT_IGNORE_LABELS))
       self.file_extension = self.json.get ('file_extension', '')
@@ -111,6 +113,7 @@ class Local:
       self.json['ignore_empty_history'] = self.ignore_empty_history
       self.json['ignore_tags'] = list(self.ignore_tags)
       self.json['ignore_remote_labels'] = list(self.ignore_remote_labels)
+      self.json['remove_local_messages'] = self.remove_local_messages
       self.json['file_extension'] = self.file_extension
 
       if os.path.exists (self.config_f):
@@ -138,6 +141,10 @@ class Local:
 
     def set_ignore_empty_history (self, r):
       self.ignore_empty_history = r
+      self.write()
+
+    def set_remove_local_messages (self, r):
+      self.remove_local_messages = r
       self.write()
 
     def set_ignore_tags (self, t):
@@ -452,6 +459,8 @@ class Local:
     """
     Remove message from local store
     """
+    assert self.config.remove_local_messages, "tried to remove message when 'remove_local_messages' was set to False"
+
     fname  = self.gids.get (gid, None)
     ffname = fname
 


### PR DESCRIPTION
…ely (fix #125)

by default set to true, this was the previous behavior when doing a
partial pull. but not when doing a full pull. when set to false and push
tries to update, this will fail with a message about 'could not find
remote message' which is otherwise ignored.