### PR TITLE
gmailieer: behave like sendmail

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,8 @@ Lieer may be used as a simple stand-in for the `sendmail` MTA. A typical configu
 gmi send -C ~/.mail/account.gmail
 ```
 
-the raw message is either read from `stdin` or a filename may be supplied.
+Like the real sendmail program, the raw message is read from `stdin`.
+Additional recipients can be passed afterwards.
 Lieer will try to associate the sent message with the existing thread if it has
 an `In-Reply-To` header. According to the [Gmail
 API](https://developers.google.com/gmail/api/v1/reference/users/messages/send#request-body)


### PR DESCRIPTION
sendmail(1) allows additional recipients to be passed in the command
line. The path to the message is never passed, it's always stdin:

> sendmail [option ...] [recipient ...]

At least neomutt makes use of the `recipient` arguments, so let's have
lieer behave properly.

Contrary to SMTP, it seems recipients can only specified inside the
message body when interacting with GMail.
If additional recipients are passed, we add them to the Bcc field.

Fixes #152