### PR TITLE
Don't print messages about ignoring files outside our working path

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -404,9 +404,7 @@ class Local:
 
     for m in msgs:
       for fname in m.get_filenames ():
-        if not self.contains (fname):
-          print ("'%s' is not in this repository, ignoring." % fname)
-        else:
+        if self.contains (fname):
           # get gmail id
           gid = self.__filename_to_gid__ (os.path.basename (fname))
           if gid:


### PR DESCRIPTION
If you are syncing two mailboxes to the same notmuch database, and those two mailboxes are both subscribed to an identical mailing list; you will end up with many many messages complaining that the message path isn't in the correct spot.

IE, messages like this will always have one side complain about the other side.
```
% notmuch show --format=json thread:0000000000000017 | jq '.[][][0] | {id: .id, filename: .filename, subject: .headers.Subject}'
{
  "id": "CAE16B76QGuYQ60BHH15f6tzTWdi-VXNvsQfjRyGeZkJZ53rZUg@mail.gmail.com",
  "filename": [
    "/home/shammas/Maildir/georgyo@gmail.com/mail/cur/17253b08bdd09ab7:2,",
    "/home/shammas/Maildir/george@shamm.as/mail/cur/17253b08b38e9a5a:2,"
  ],
  "subject": "[NYCResistor] May 26th 2020"
}
```

As this message is stating operating correctly, I think it is safe to remove the print.

fixes #97 