### PR TITLE
Add --local-trash-tag option.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,9 @@ Lieer can be configured using `gmi set`. Use without any options to get a list o
   
   *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
 
+**`Local Trash Tag (local)`** can be used to set the local tag to which the remote GMail 'TRASH' label is translated.
+
+  *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
 
 ## Changing ignored tags and translation after initial sync
 
@@ -187,11 +190,12 @@ Before changing either setting make sure you are fully synchronized. After chang
 
 When changing the opposite setting: `--ignore-tags-local`, do a full push (dry-run first): `gmi push -f --dry-run`.
 
-The same goes for the option `--replace-slash-with-dot`. I prefer to do `gmi pull -f --dry-run` after changing this option. This will overwrite the local tags with the remote labels.
+The same goes for the options `--replace-slash-with-dot` and `--local-trash-tag`. I prefer to do `gmi pull -f --dry-run` after changing this option. This will overwrite the local tags with the remote labels.
+
 
 # Translation between labels and tags
 
-We translate some of the GMail labels to other tags. The map of labels to tags are:
+We translate some of the GMail labels to other tags. The default map of labels to tags are:
 
 ```py
   'INBOX'     : 'inbox',
@@ -210,6 +214,8 @@ We translate some of the GMail labels to other tags. The map of labels to tags a
   'CATEGORY_UPDATES'      : 'updates',
   'CATEGORY_FORUMS'       : 'forums',
 ```
+
+The 'trash' local tag can be replaced using the `--local-trash-tag` option.
 
 # Using your own API key
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -200,6 +200,9 @@ class Gmailieer:
     parser_set.add_argument ('--no-remove-local-messages', action = 'store_true', default = False,
         help = 'Do not remove messages that have been deleted on the remote')
 
+    parser_set.add_argument ('--local-trash-tag', type = str, default = None,
+        help = 'The local tag to use for the remote label TRASH.')
+
     parser_set.set_defaults (func = self.set)
 
 
@@ -875,6 +878,9 @@ class Gmailieer:
     if args.file_extension is not None:
       self.local.config.set_file_extension (args.file_extension)
 
+    if args.local_trash_tag is not None:
+      self.local.config.set_local_trash_tag (args.local_trash_tag)
+
     print ("Repository information and settings:")
     print ("Account ...........: %s" % self.local.config.account)
     print ("historyId .........: %d" % self.local.state.last_historyId)
@@ -887,6 +893,7 @@ class Gmailieer:
     print ("Replace . with / ..........:", self.local.config.replace_slash_with_dot)
     print ("Ignore tags (local) .......:", self.local.config.ignore_tags)
     print ("Ignore labels (remote) ....:", self.local.config.ignore_remote_labels)
+    print ("Trash tag (local) .........:", self.local.config.local_trash_tag)
 
   def vprint (self, *args, **kwargs):
     """


### PR DESCRIPTION
Here is a patch to add a --local-trash-tag option which updates the Local translation map.  It is minor and I've added it to the documentation.  Thoughts?