### PR TITLE
update backoff recovery to be more aggressive

### DIFF
--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -333,16 +333,16 @@ class Remote:
       try:
         batch.execute (http = self.http)
 
-        # gradually reduce user delay if we had 10 ok batches
+        # gradually reduce user delay upon every ok batch
         user_rate_ok += 1
-        if user_rate_delay > 0 and user_rate_ok > 10:
+        if user_rate_delay > 0 and user_rate_ok > 0:
           user_rate_delay = user_rate_delay // 2
           print ("remote: decreasing delay to %s" % user_rate_delay)
           user_rate_ok    = 0
 
-        # gradually increase batch request size if we had 10 ok requests
+        # gradually increase batch request size upon every ok request
         req_ok += 1
-        if max_req < self.BATCH_REQUEST_SIZE and req_ok > 10:
+        if max_req < self.BATCH_REQUEST_SIZE and req_ok > 0:
           max_req = min (max_req * 2, self.BATCH_REQUEST_SIZE)
           print ("remote: increasing batch request size to: %d" % max_req)
           req_ok  = 0


### PR DESCRIPTION
Partially recover from exponential backoff after every successful request/batch,
rather than waiting for 10 successes.

This appears to speed up large syncs. In large syncs, the current code (before this change is applied) appears to spend most of its time waiting about 31 seconds in between batches. This is unnecessary; as you can see by running with the proposed change, Google usually accepts a partial recovery from backoff after waiting 31 seconds.

As far as i can tell, https://developers.google.com/gmail/api/guides/handle-errors#exponential-backoff does not mandate waiting for multiple successes before recovering from backoff.