### PR TITLE
fix bug where saved local-trash-tag config option was ignored

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -295,6 +295,7 @@ class Local:
     self.state = Local.State (self.state_f, self.config)
 
     self.ignore_labels = self.ignore_labels | self.config.ignore_tags
+    Local.update_translation('TRASH', self.config.local_trash_tag)
 
     ## Check if we are in the notmuch db
     with notmuch.Database () as db:


### PR DESCRIPTION
My local-trash-tag config option was being ignored, even though "gmi set" showed:
```
Trash tag (local) .........: deleted
```

I think what was happening may have been that ```Local.update_translation('TRASH', self.local_trash_tag)``` was only being called from within ```set_local_trash_tag```, which i assume is called 
when --local-trash-tag was provided on the commandline, but not when it is found in the saved configuration.

This change runs ```Local.update_translation('TRASH', self.config.local_trash_tag)``` from within ```load_repository```.