### PR TITLE
add --translation-list-overlay option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,11 @@ Lieer can be configured using `gmi set`. Use without any options to get a list o
 
   *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
 
+**`Translation List Overlay`** can be used to add or change entries in the translation mapping between local and remote tags. Argument is a comment-separated list with an even number of items. This is interpreted as a list of pairs of (remote, local), where each pair is added to the tag translation overwriting any existing translation for that tag if any. For example,
+`--translation-list-overlay CATEGORY_FORUMS,my_forum_tag` will translate Google's CATEGORY_FORUMS tag to my_forum_tag.')
+
+  *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).
+
 ## Changing ignored tags and translation after initial sync
 
 If you change the [ignored tags](#settings) after the initial sync this will not update already synced messages. This means that if a change is made locally on an already synced message the previously ignored remote labels may be deleted. Conversely, if a change occurs remotely on a message which previously which has local tags that were ignored before, these ignored tags may be deleted.

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -203,6 +203,9 @@ class Gmailieer:
     parser_set.add_argument ('--local-trash-tag', type = str, default = None,
         help = 'The local tag to use for the remote label TRASH.')
 
+    parser_set.add_argument ('--translation-list-overlay', type = str, default = None,
+        help = 'A list with an even number of items representing a list of pairs of (remote, local), where each pair is added to the tag translation.')
+    
     parser_set.set_defaults (func = self.set)
 
 
@@ -881,6 +884,9 @@ class Gmailieer:
     if args.local_trash_tag is not None:
       self.local.config.set_local_trash_tag (args.local_trash_tag)
 
+    if args.translation_list_overlay is not None:
+      self.local.config.set_translation_list_overlay (args.translation_list_overlay)
+      
     print ("Repository information and settings:")
     print ("Account ...........: %s" % self.local.config.account)
     print ("historyId .........: %d" % self.local.state.last_historyId)
@@ -894,6 +900,7 @@ class Gmailieer:
     print ("Ignore tags (local) .......:", self.local.config.ignore_tags)
     print ("Ignore labels (remote) ....:", self.local.config.ignore_remote_labels)
     print ("Trash tag (local) .........:", self.local.config.local_trash_tag)
+    print ("Translation list overlay ..:", self.local.config.translation_list_overlay)
 
   def vprint (self, *args, **kwargs):
     """


### PR DESCRIPTION
This PR adds a --translation-list-overlay option that allows additions and changes to the label/tag translation list. For example,  

```
--translation-list-overlay CATEGORY_FORUMS,my_forum_tag,another_gmail_label,my_local_label
```

creates the mappings:
```
CATEGORY_FORUMS     <--> my_forum_tag
another_gmail_label <--> another_local_tag
```

To give some idea why this might be useful, I have two Gmail accounts and I use filtering on the server to forward certain emails from account1 to account2, and then delete them from account1. However, if both are being sync'd to my local machine, then this filtering rule assigns a 'TRASH' label to the email in account1, which then in some cases is propagated to account2, causing the email to be deleted everywhere, which is not what i want. I am planning to try mapping 'TRASH' on account1 to 'trash_account1', and similarly for INBOX and for account2. In this way, the inbox/trash state of the email will be distinct for my two accounts, even though notmuch only maintains one set of tags for each message-id.