### PR TITLE
docs: fix `` rendering for pip install instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ While Lieer has been used to successfully synchronize millions of messages and t
 
 ## Installation
 
-After cloning the repository Lieer can be installed through pip by using the command ```pip install .``
+After cloning the repository Lieer can be installed through pip by using the command ```pip install .```
 # Usage
 
 This assumes your root mail folder is in `~/.mail` and that this folder is _already_ set up with notmuch.


### PR DESCRIPTION
commit 968d2a73c2de ("Update README to use pip instead of setup.py method")
forgot a third backquote in the pip install command.

Add it to fix GitHub's web rendering.

Fixes: 968d2a73c2de ("Update README to use pip instead of setup.py method")
Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>