### PR TITLE
Fix call to `Database.find` for new notmuch2 API

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -817,7 +817,10 @@ class Gmailieer:
       repl = eml['In-Reply-To'].strip().strip('<>')
       self.vprint("looking for original message: %s" % repl)
       with notmuch2.Database(mode = notmuch2.Database.MODE.READ_ONLY) as db:
-        nmsg = db.find(repl)
+        try:
+          nmsg = db.find(repl)
+        except LookupError:
+          nmsg = None
         if nmsg is not None:
           (_, gids) = self.local.messages_to_gids([nmsg])
           if nmsg.header('Subject') != eml['Subject']:


### PR DESCRIPTION
I'm seeing this backtrace when sending some emails (note that this is in my personal hacked up version of lieer, so the line numbers and call stack won't match exactly):

```
sending message, from: xxxxxx xxxxxx <xxxxx@xx.x>..
looking for original message: xxxxxxxx@xxxxx.xx> (Xxxx Xxxxxxx's message of "Thu, 24 Nov
	2022 XX:XX:XX +0000")
Traceback (most recent call last):
  File "/home/skangas/src/lieer/gmi", line 24, in <module>
    g.main ()
  File "/home/skangas/src/lieer/lieer/gmailieer.py", line 232, in main
    args.func (args)
  File "/home/skangas/src/lieer/lieer/gmailieer.py", line 899, in manage_queue
    self.send (args, msg)
  File "/home/skangas/src/lieer/lieer/gmailieer.py", line 835, in send
    nmsg = db.find(repl)
  File "/usr/lib/python3/dist-packages/notmuch2/_database.py", line 505, in find
    raise LookupError
LookupError
```

I traced it down to a change in the API from the `notmuch` to the `notmuch2` bindings: the old [Database.find_message()](72c298abcd794f150bac6ec9614c231b0a153295) returns `None` when no message is found, but the new [Database.find()](https://www.cs.unb.ca/~bremner/scratch/notmuch-doc-wip/python-bindings.html#notmuch2.Database.find) instead raises a `LookupError`. This PR fixes that.

See also 72c298abcd794f150bac6ec9614c231b0a153295.

Thanks.