### PR TITLE
Use Loopback IP address auth flow instead of deprecated OOB

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -145,6 +145,17 @@ class Gmailieer:
     parser_auth.add_argument ('-f', '--force', action = 'store_true',
         default = False, help = 'Re-authorize')
 
+    # These are taken from oauth2lib/tools.py for compatibility with its
+    # run_flow() method used during oauth
+    parser_auth.add_argument('--auth-host-name', default='localhost',
+        help='Hostname when running a local web server')
+    parser_auth.add_argument('--auth-host-port', default=[8080, 8090], type=int,
+        nargs='*',
+        help='Port web server should listen on')
+    parser_auth.add_argument('--noauth_local_webserver', action='store_true',
+        default=False,
+        help='Do not run a local web server (no longer supported by Google)')
+
     parser_auth.set_defaults (func = self.authorize)
 
     # init


### PR DESCRIPTION
This should fix the authorization flow, as discussed in #215. @tohojo already did all the heavy lifting and wrote up a patch, so I just tested that it works and made this pull request.

I would have actually preferred to put the commit in Toke's name, but I didn't want to do so without his consent. Instead, I acknowledge him in a `Co-authored-by` tag in the commit message. If Toke prefers, I'm obviously happy to make him the author instead. (My own changes were minimal.)

The patch works here, but more testing is obviously welcome.

For reference, see:
https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html
https://developers.google.com/identity/protocols/oauth2/resources/oob-migration