### PR TITLE
remote: oauth2: migrate from deprecated oauth2client library

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ While Lieer has been used to successfully synchronize millions of messages and t
 * Python 3
 * `notmuch >= 0.25` python bindings
 * `google_api_python_client` (sometimes `google-api-python-client`)
-* `oauth2client`
+* `google_auth_oauthlib`
 * `tqdm` (optional - for progress bar)
 
 ## Installation

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -21,7 +21,6 @@
 import  os
 import  sys
 import  argparse
-from    oauth2client import tools
 import  googleapiclient
 import  googleapiclient.errors
 import  notmuch2
@@ -33,7 +32,7 @@ class Gmailieer:
   cwd = None
 
   def main (self):
-    parser = argparse.ArgumentParser ('gmi', parents = [tools.argparser])
+    parser = argparse.ArgumentParser ('gmi')
     self.parser = parser
 
     common = argparse.ArgumentParser (add_help = False)

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -17,7 +17,6 @@
 
 import os
 import time
-import httplib2
 import googleapiclient
 from apiclient import discovery
 from google_auth_oauthlib.flow import InstalledAppFlow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-api-python-client
-oauth2client
+google_auth_oauthlib
 tqdm
 notmuch2

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['oauth2client', 'google-api-python-client', 'tqdm', 'notmuch2'],
+    install_requires=['google_auth_oauthlib', 'google-api-python-client', 'tqdm', 'notmuch2'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
oauth2client lib is deprecated and hasn't been updated in a while.

replace it with google-auth.