### PR TITLE
Add verbose option to sync

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -135,6 +135,9 @@ class Gmailieer:
     parser_sync.add_argument ('-d', '--dry-run', action='store_true',
         default = False, help = 'do not make any changes')
 
+    parser_sync.add_argument ('-v', '--verbose', action='store_true',
+        default = False, help = 'print list of changes')
+
     parser_sync.add_argument ('-f', '--force', action = 'store_true',
         default = False, help = 'Push even when there has been remote changes, and force a full remote-to-local synchronization')
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -281,9 +281,13 @@ class Gmailieer:
         raise NotADirectoryError("error: %s is not a valid path!" % args.path)
 
     self.dry_run          = dry_run
-    self.verbose          = args.verbose
     self.HAS_TQDM         = (not args.no_progress)
     self.credentials_file = args.credentials
+
+    try:
+      self.verbose        = args.verbose
+    except AttributeError:
+      self.verbose        = False
 
     if self.HAS_TQDM:
       if not (sys.stderr.isatty() and sys.stdout.isatty()):


### PR DESCRIPTION
Fixes f7c3f594ee4a04c8289e8431df9d2e5470affc56 which broke sync:

```
Traceback (most recent call last):
  File "/usr/bin/gmi", line 24, in <module>
    g.main ()
  File "/usr/lib/python3.11/site-packages/lieer/gmailieer.py", line 236, in main
    args.func (args)
  File "/usr/lib/python3.11/site-packages/lieer/gmailieer.py", line 307, in sync
    self.setup (args, args.dry_run, True)
  File "/usr/lib/python3.11/site-packages/lieer/gmailieer.py", line 281, in setup
    self.verbose          = args.verbose
                            ^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'verbose'
```