### PR TITLE
Make GitHub workflow test also on Python 3.10-3.11

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,15 +15,18 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
       with:
         persist-credentials: false
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
     - name: Install notmuch
       run: |
         sudo apt-get install notmuch


### PR DESCRIPTION
This should make the GitHub test workflow test also with newer versions of Python.

More information:
https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python