### PR TITLE
Fix gmi send -d (dry-run)

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -1093,8 +1093,9 @@ class Gmailieer:
             msg = self.remote.send(msg, threadId)
             self.get_content([msg["id"]])
             self.get_meta([msg["id"]])
-
-        self.vprint("message sent successfully: %s" % msg["id"])
+            self.vprint("message sent successfully: %s" % msg["id"])
+        else:
+            self.vprint("message sent successfully: dry-run")
 
     def set(self, args):
         args.credentials = ""  # for setup()


### PR DESCRIPTION
msg within send function is used to read in stdin first. Later on in the function msg is used to get back data from the message send, however this occurs inside a `not dry-run` condition.

When a dry-run is made, msg is not updated and holds stale data from stdin.read. The function then fails trying to print the stale msg data.

Fix by seperating into two print statements, one for the dry-run, and one without.

Closes #259 (hopefully)