### PR TITLE
Add .venv and .dir-locals.el to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 *.pyc
 client_secret.json
+.venv
 .gmailieer.json
 mail
 build
 dist
 *.egg-info
+
+# Emacs
+.dir-locals.el


### PR DESCRIPTION
This just adds to `.gitignore` two files that I tend to use: the semi-standard `.venv` directory and the Emacs file `.dir-locals.el` (for directory local variables.