### PR TITLE
Enable ruff rules: executable, bandit

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -34,11 +34,12 @@ target-version = "py39"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "I", "UP", "C4", "EXE", "SIM", "PERF"]
+select = ["E4", "E7", "E9", "F", "I", "UP", "S", "C4", "EXE", "SIM", "PERF"]
 ignore = [
     "E501",  # Line too long
     "E741",  # Ambiguous variable name: `l`
     "F403",  # `from .gmailieer import *` used; unable to detect undefined names
+    "S101",  # Use of `assert` detected
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -34,7 +34,7 @@ target-version = "py39"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "I", "UP", "C4", "SIM", "PERF"]
+select = ["E4", "E7", "E9", "F", "I", "UP", "C4", "EXE", "SIM", "PERF"]
 ignore = [
     "E501",  # Line too long
     "E741",  # Ambiguous variable name: `l`

--- a/lieer/nobar.py
+++ b/lieer/nobar.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python3
-#
 # Regular non-TTY drop-in replacement for tqdm
 #
 # Copyright © 2020  Gaute Hope <eg@gaute.vetsj.com>


### PR DESCRIPTION
This enables two more ruff rules: flake8-executable for consistency, and flake8-bandit for security checks.

I disabled the rule about asserts, which has been described as "alarmist at best" by the flake8 maintainer: https://stackoverflow.com/a/68429294