### PR TITLE
Require Notmuch 0.30+ for `notmuch2` Python bindings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ While Lieer has been used to successfully synchronize millions of messages and t
 ## Requirements
 
 * Python 3
-* `notmuch >= 0.25` python bindings
+* Notmuch 0.30+ for `notmuch2` Python bindings
 * `google_api_python_client` (sometimes `google-api-python-client`)
 * `google_auth_oauthlib`
 * `tqdm` (optional - for progress bar)


### PR DESCRIPTION
As of #173 "Migrate to notmuch2" etc., Lieer uses the `notmuch2` Python bindings, which have first been shipped in Notmuch 0.30.  (..., and 0.30 appears to still work fine for current Lieer, as I've just tried.)