### PR TITLE
Specifically mention git-send-email in setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,9 @@ Lieer may be used as a simple stand-in for the `sendmail` MTA. A typical configu
 gmi send -t -C ~/.mail/account.gmail
 ```
 
+For example, you can enable git send-email with `git config sendemail.sendmailcmd "gmi send -t -C
+$HOME/.mail/account.gmail"`.
+
 Like the real sendmail program, the raw message is read from `stdin`.
 
 Most sendmail implementations allow passing additional recipients in additional


### PR DESCRIPTION
Looking up the git config key isn't the most obvious thing, so this will make it easier for people to migrate off app-specific passwords. There are _so many_ places online where that is listed as the only possible way to make git-send-email work.