### PR TITLE
Remove tests from installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     keywords="gmail notmuch synchronization tags",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:
     #   py_modules=["my_module"],


### PR DESCRIPTION
The tests do not need to be installed

Create an exclude rule for find_packages() in setup

This is a slight issue that prevents packaging "cleanly" for gentoo, details here:
https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages