### PR TITLE
docs: fix indentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,36 +34,35 @@ This assumes your root mail folder is in `~/.mail` and that this folder is _alre
 
 1. Make a directory for the lieer storage and state files (local repository).
 
-```sh
-$ cd    ~/.mail
-$ mkdir account.gmail
-$ cd    account.gmail/
-```
+   ```sh
+   $ cd    ~/.mail
+   $ mkdir account.gmail
+   $ cd    account.gmail/
+   ```
 
-All commands should be run from the local mail repository unless otherwise specified.
-
+   All commands should be run from the local mail repository unless otherwise specified.
 
 2. Ignore the `.json` files in notmuch. Any tags listed in `new.tags` will be added to newly pulled messages. Process tags on new messages directly after running gmi, or run `notmuch new` to trigger the `post-new` hook for [initial tagging](https://notmuchmail.org/initial_tagging/). The `new.tags` are not ignored by default if you do not remove them, but you can prevent custom tags from being pushed to the remote by using e.g. `gmi set --ignore-tags-local new`. In your notmuch config file (usually `~/.notmuch-config`):
 
-```
-[new]
-tags=new
-ignore=/.*[.](json|lock|bak)$/
-```
+   ```
+   [new]
+   tags=new
+   ignore=/.*[.](json|lock|bak)$/
+   ```
 
 3. Initialize the mail storage:
 
-```sh
-$ gmi init your.email@gmail.com
-```
+   ```sh
+   $ gmi init your.email@gmail.com
+   ```
 
-`gmi init` will now open your browser and request limited access to your e-mail.
+   `gmi init` will now open your browser and request limited access to your e-mail.
 
-> The access token is stored in `.credentials.gmailieer.json` in the local mail repository. If you wish, you can specify [your own api key](#using-your-own-api-key) that should be used.
+   > The access token is stored in `.credentials.gmailieer.json` in the local mail repository. If you wish, you can specify [your own api key](#using-your-own-api-key) that should be used.
 
 4. You're now set up, and you can do the initial pull.
 
-> Use `gmi -h` or `gmi command -h` to get more usage information.
+   > Use `gmi -h` or `gmi command -h` to get more usage information.
 
 ## Pull
 


### PR DESCRIPTION
The numbered list was being reset because the content was outdented.