### PR TITLE
Added default translations to the new star-color labels that Gmail is now reporting.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -220,11 +220,25 @@ We translate some of the GMail labels to other tags. The default map of labels t
   'DRAFT'     : 'draft',
   'CHAT'      : 'chat',
 
-  'CATEGORY_PERSONAL'     : 'personal',
-  'CATEGORY_SOCIAL'       : 'social',
-  'CATEGORY_PROMOTIONS'   : 'promotions',
-  'CATEGORY_UPDATES'      : 'updates',
-  'CATEGORY_FORUMS'       : 'forums',
+  'CATEGORY_PERSONAL'   : 'personal',
+  'CATEGORY_SOCIAL'     : 'social',
+  'CATEGORY_PROMOTIONS' : 'promotions',
+  'CATEGORY_UPDATES'    : 'updates',
+  'CATEGORY_FORUMS'     : 'forums',
+
+  'BLUE_STAR'   : 'blue_star',
+  'GREEN_STAR'  : 'green_star',
+  'ORANGE_STAR' : 'orange_star',
+  'PURPLE_STAR' : 'purple_star',
+  'RED_STAR'    : 'red_star',
+  'YELLOW_STAR' : 'yellow_star',
+
+  'BLUE_CIRCLE'   : 'blue_circle',
+  'GREEN_CIRCLE'  : 'green_circle',
+  'ORANGE_CIRCLE' : 'orange_circle',
+  'PURPLE_CIRCLE' : 'purple_circle',
+  'RED_CIRCLE'    : 'red_circle',
+  'YELLOW_CIRCLE' : 'yellow_circle',
 ```
 
 The 'trash' local tag can be replaced using the `--local-trash-tag` option.

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -48,6 +48,18 @@ class Local:
         "CATEGORY_PROMOTIONS": "promotions",
         "CATEGORY_UPDATES": "updates",
         "CATEGORY_FORUMS": "forums",
+        "BLUE_STAR": "blue_star",
+        "GREEN_STAR": "green_star",
+        "ORANGE_STAR": "orange_star",
+        "PURPLE_STAR": "purple_star",
+        "RED_STAR": "red_star",
+        "YELLOW_STAR": "yellow_star",
+        "BLUE_CIRCLE": "blue_circle",
+        "GREEN_CIRCLE": "green_circle",
+        "ORANGE_CIRCLE": "orange_circle",
+        "PURPLE_CIRCLE": "purple_circle",
+        "RED_CIRCLE": "red_circle",
+        "YELLOW_CIRCLE": "yellow_circle",
     }
 
     labels_translate_default = {v: k for k, v in translate_labels_default.items()}


### PR DESCRIPTION
The Gmail API is now reporting star-color labels and other non-star "stars" and colors, but they are in uppercase. This branch adds default label translations to convert them to lowercase, consistent with other default label translations.