### PR TITLE
local: gracefully fail if the lock is already taken

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -416,7 +416,11 @@ class Gmailieer:
         if args.quiet:
             args.no_progress = True
 
-        args.func(args)
+        try:
+            args.func(args)
+        except Local.LockingException as e:
+            print(e, file=sys.stderr)
+            sys.exit(7)
 
     def initialize(self, args):
         self.setup(args, False)

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import base64
+import errno
 import fcntl
 import json
 import os
@@ -114,6 +115,9 @@ class Local:
             self.labels_translate[local] = remote
 
     class RepositoryException(Exception):
+        pass
+
+    class LockingException(RepositoryException):
         pass
 
     class Config:
@@ -382,10 +386,14 @@ class Local:
                 fcntl.lockf(self.lckf, fcntl.LOCK_EX)
             else:
                 fcntl.lockf(self.lckf, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            raise Local.RepositoryException(
-                "failed to lock repository (probably in use by another gmi instance)"
-            )
+        except OSError as e:
+            if e.errno in (errno.EACCES, errno.EAGAIN):
+                # Lock already taken, works as intended
+                raise Local.LockingException(
+                    "failed to lock repository (probably in use by another gmi instance)"
+                ) from None
+            # otherwise probably irrecoverable, keep the raw exception to help debugging
+            raise
 
         self.config = Local.Config(self.config_f)
         self.state = Local.State(self.state_f, self.config)


### PR DESCRIPTION
An EACCES or EAGAIN error on a non-blocking lockf is not actually an error, but rather the program working as intended. At this stage, any other error is unexpected and should probably be left alone.

The tailor-made exception can be caught in our main function to display a short error string and use a specific error code for the user to act accordingly. This is much more user-friendly (and machine-friendly) than the standard python uncaught exception handler.