### PR TITLE
local: add support for database.mail_root notmuch config option

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -367,8 +367,9 @@ class Local:
 
         ## Check if we are in the notmuch db
         with notmuch2.Database() as db:
+            mail_root = db.config.get("database.mail_root", db.path)
             try:
-                self.nm_relative = str(Path(self.md).relative_to(db.path))
+                self.nm_relative = str(Path(self.md).relative_to(mail_root))
             except ValueError:
                 raise Local.RepositoryException(
                     "local mail repository not in notmuch db"


### PR DESCRIPTION
This option was introduced in 0.32, and allows for the DB path to be decorrelated to the maildir location. See notmuch-config(1) for details.